### PR TITLE
Fix exports and clean up API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,26 @@ export default () => {
 #### Dependency registration
 
 ```js
-import CsrfProtection, {FetchForCsrfToken} from 'fusion-plugin-csrf-protection';
+import CsrfProtection, {
+  FetchForCsrfToken,
+  CsrfExpireToken,
+  CsrfIgnoreRoutesToken,
+} from 'fusion-plugin-csrf-protection';
 import {FetchToken, SessionToken} from 'fusion-tokens';
 
-app.register(SessionToken, Session);
-app.register(FetchForCsrfToken, fetch);
 app.register(FetchToken, CsrfProtection);
+app.register(FetchForCsrfToken, fetch);
+app.register(CsrfExpireToken, expires);
+app.register(CsrfIgnoreRoutesToken, ignoredRoutes);
+app.register(SessionToken, Session);
 ```
 
 The `fusion-plugin-csrf-protection` module provides an api that matches the `fetch` api,
 and therefore can be registered on the standard `FetchToken` exported by `fusion-tokens`.
 
 * `fetch: (url: string, options: Object) => Promise` - A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.
+* `expires: number` - Optional. Defaults to 86400 (seconds). When to expire the token.
+* `ignoredRoutes: Array<string>` - Optional. Defaults to `[]`. A list of paths that should not be gated by CSRF protection. For example `['/_errors']` would allow error logging requests to `/_errors` to be sent without a CSRF token.
 * `Session` - a Session plugin, such as the one provided by [`fusion-plugin-jwt`](https://github.com/fusionjs/fusion-plugin-jwt).
   The Session instance should expose a `get: (key: string) => string` and `set: (key: string, value: string) => string` methods.
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,21 @@ yarn add fusion-plugin-csrf-protection
 ```js
 // src/main.js
 import React from 'react';
-import {FetchToken, SessionToken, createToken} from 'fusion-tokens';
+import {FetchToken, SessionToken} from 'fusion-tokens';
 import App from 'fusion-react';
 import Session from 'fusion-plugin-jwt';
-import CsrfProtection from 'fusion-plugin-csrf-protection';
+import CsrfProtection, {FetchForCsrfToken} from 'fusion-plugin-csrf-protection';
 import fetch from unfetch;
-
-const BaseFetchToken = createToken('BaseFetch');
 
 export default () => {
   const app = new App(<div></div>);
 
   app.register(SessionToken, Session);
-  app.register(BaseFetchToken, fetch);
-  app.register(FetchToken, CsrfProtection).alias(FetchToken, BaseFetchToken);
+  app.register(FetchForCsrfToken, fetch);
+  app.register(FetchToken, CsrfProtection);
 
   if (__BROWSER__) {
-    app.register(BaseFetchToken, window.fetch);
+    app.register(FetchForCsrfToken, fetch);
     app.middleware({fetch: FetchToken}, ({fetch}) => {
       // makes a pre-flight request for CSRF token if required,
       // and prevents POST calls to /api/hello without a valid token
@@ -58,32 +56,22 @@ export default () => {
 #### Dependency registration
 
 ```js
-import {CsrfProtection} from 'fusion-plugin-csrf-protection';
-import {FetchToken, createToken} from 'fusion-tokens';
-const BaseFetchToken = createToken('BaseFetch');
+import CsrfProtection, {FetchForCsrfToken} from 'fusion-plugin-csrf-protection';
+import {FetchToken, SessionToken} from 'fusion-tokens';
 
 app.register(SessionToken, Session);
-app.register(BaseFetch, fetch);
-app.register(FetchToken, CsrfProtection).alias(FetchToken, BaseFetchToken);
+app.register(FetchForCsrfToken, fetch);
+app.register(FetchToken, CsrfProtection);
 ```
 
 The `fusion-plugin-csrf-protection` module provides an api that matches the `fetch` api,
 and therefore can be registered on the standard `FetchToken` exported by `fusion-tokens`.
-However, since `fusion-plugin-csrf-protection` also depends on an implementation of `fetch`
-it is recommended to use token aliasing.
 
-#### Dependencies
+* `fetch: (url: string, options: Object) => Promise` - A [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) implementation.
+* `Session` - a Session plugin, such as the one provided by [`fusion-plugin-jwt`](https://github.com/fusionjs/fusion-plugin-jwt).
+  The Session instance should expose a `get: (key: string) => string` and `set: (key: string, value: string) => string` methods.
 
-##### `FetchToken`
-
-This plugin depends on an implementation of `fetch` registered on the standard `FetchToken` exported from `fusion-tokens`. Since you likely want to register `fusion-plugin-csrf-protection` back onto the `FetchToken`, it is recommended to use token aliasing.
-
-##### `SessionToken`
-
-This plugin depends on a A Session plugin, such as the one provided by [`fusion-plugin-jwt`](https://github.com/fusionjs/fusion-plugin-jwt).
-The Session instance should expose a `get: (key: string) => string` and `set: (key: string, value: string) => string` methods.
-
-#### Instance Api
+#### Instance API
 
 ```js
 if (__BROWSER__) {

--- a/src/__tests__/test.browser.js
+++ b/src/__tests__/test.browser.js
@@ -7,16 +7,14 @@
 /* eslint-env browser */
 import test from 'tape-cup';
 import App, {createPlugin} from 'fusion-core';
-import {FetchToken, createToken} from 'fusion-tokens';
+import {FetchToken} from 'fusion-tokens';
 import CsrfPlugin from '../index';
-import {CSRFTokenExpire} from '../shared';
-
-const BaseFetchToken = createToken('BaseFetch');
+import {CsrfExpireToken, FetchForCsrfToken} from '../shared';
 
 function getApp(fetchFn) {
   const app = new App('element', el => el);
-  app.register(BaseFetchToken, fetchFn);
-  app.register(FetchToken, CsrfPlugin).alias(FetchToken, BaseFetchToken);
+  app.register(FetchForCsrfToken, fetchFn);
+  app.register(FetchToken, CsrfPlugin);
   return app;
 }
 
@@ -224,7 +222,7 @@ test('fetch preflights if token is expired', t => {
     });
   };
   const app = getApp(fetch);
-  app.register(CSRFTokenExpire, 1);
+  app.register(CsrfExpireToken, 1);
   app.register(
     createPlugin({
       deps: {fetch: FetchToken},

--- a/src/__tests__/test.node.js
+++ b/src/__tests__/test.node.js
@@ -9,7 +9,7 @@ import test from 'tape-cup';
 import {SessionToken} from 'fusion-tokens';
 import {getSimulator} from 'fusion-test-utils';
 import CsrfPlugin from '../server';
-import {CSRFTokenExpire, CSRFIgnoreRoutes} from '../shared';
+import {CsrfExpireToken, CsrfIgnoreRoutesToken} from '../shared';
 
 function getSession() {
   const state = {};
@@ -172,7 +172,7 @@ test('fails with expired token', async t => {
   const Session = getSession();
   const app = new App('fake-element', el => el);
   app.register(SessionToken, Session);
-  app.register(CSRFTokenExpire, 1);
+  app.register(CsrfExpireToken, 1);
   app.register(CsrfPlugin);
   const simulator = getSimulator(app);
 
@@ -198,7 +198,7 @@ test('does not verify ignored paths', async t => {
   const app = new App('fake-element', el => el);
   app.register(SessionToken, Session);
   app.register(CsrfPlugin);
-  app.register(CSRFIgnoreRoutes, ['/test']);
+  app.register(CsrfIgnoreRoutesToken, ['/test']);
   app.middleware((ctx, next) => {
     if (ctx.path === '/test') ctx.body = {ok: 1};
     return next();

--- a/src/browser.js
+++ b/src/browser.js
@@ -7,13 +7,17 @@
 // @flow
 /* eslint-env browser */
 import {unescape, createPlugin} from 'fusion-core';
-import {FetchForCsrfToken} from './tokens';
-import {verifyMethod, verifyExpiry, CSRFTokenExpire} from './shared';
+import {
+  verifyMethod,
+  verifyExpiry,
+  CsrfExpireToken,
+  FetchForCsrfToken,
+} from './shared';
 
 const BrowserCSRFPlugin = createPlugin({
   deps: {
     fetch: FetchForCsrfToken,
-    expire: CSRFTokenExpire,
+    expire: CsrfExpireToken,
   },
   provides: ({fetch, expire}) => {
     const prefix = window.__ROUTE_PREFIX__ || ''; // created by fusion-core/src/server

--- a/src/browser.js
+++ b/src/browser.js
@@ -7,12 +7,12 @@
 // @flow
 /* eslint-env browser */
 import {unescape, createPlugin} from 'fusion-core';
-import {FetchToken} from 'fusion-tokens';
+import {FetchForCsrfToken} from './tokens';
 import {verifyMethod, verifyExpiry, CSRFTokenExpire} from './shared';
 
 const BrowserCSRFPlugin = createPlugin({
   deps: {
-    fetch: FetchToken,
+    fetch: FetchForCsrfToken,
     expire: CSRFTokenExpire,
   },
   provides: ({fetch, expire}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,8 @@ import clientCsrf from './browser';
 
 export default (__NODE__ ? serverCsrf : clientCsrf);
 
-export {FetchToken} from './tokens';
+export {
+  FetchForCsrfToken,
+  CsrfExpireToken,
+  CsrfIgnoreRoutesToken,
+} from './shared';

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,5 @@ import serverCsrf from './server';
 import clientCsrf from './browser';
 
 export default (__NODE__ ? serverCsrf : clientCsrf);
+
+export {FetchToken} from './tokens';

--- a/src/server.js
+++ b/src/server.js
@@ -11,8 +11,8 @@ import base64Url from 'base64-url';
 import {
   verifyMethod,
   verifyExpiry,
-  CSRFIgnoreRoutes,
-  CSRFTokenExpire,
+  CsrfIgnoreRoutesToken,
+  CsrfExpireToken,
 } from './shared';
 
 // @flow
@@ -52,8 +52,8 @@ function loadOrGenerateSecret(session) {
 const CsrfPlugin = createPlugin({
   deps: {
     Session: SessionToken,
-    expire: CSRFTokenExpire,
-    ignored: CSRFIgnoreRoutes,
+    expire: CsrfExpireToken,
+    ignored: CsrfIgnoreRoutesToken,
   },
   provides: () => () =>
     Promise.reject(new Error('Cannot use fetch on the server')),
@@ -79,8 +79,7 @@ const CsrfPlugin = createPlugin({
       if (!isMatchingToken || !isValidToken) {
         const message = __DEV__
           ? 'CSRF Token configuration error: ' +
-            'add the option {fetch: CsrfToken.fetch} to ' +
-            'the 2nd argument of app.plugin(yourPlugin)'
+            'register the CsrfProtection plugin to FetchToken'
           : 'Invalid CSRF Token';
         ctx.throw(403, message);
       } else {

--- a/src/shared.js
+++ b/src/shared.js
@@ -5,7 +5,7 @@
  */
 
 // @flow
-import {createOptionalToken} from 'fusion-tokens';
+import {createToken, createOptionalToken} from 'fusion-tokens';
 
 const methods = {POST: 1, PUT: 1, PATCH: 1, DELETE: 1};
 
@@ -20,8 +20,9 @@ export function verifyExpiry(token: string, expire: number) {
   return true;
 }
 
-export const CSRFTokenExpire = createOptionalToken('CSRFTokenExpire', 86400);
-export const CSRFIgnoreRoutes: Array<string> = createOptionalToken(
-  'CSRFIgnoreRoutes',
+export const CsrfExpireToken = createOptionalToken('CsrfExpireToken', 86400);
+export const CsrfIgnoreRoutesToken: Array<string> = createOptionalToken(
+  'CsrfIgnoreRoutesToken',
   []
 );
+export const FetchForCsrfToken = createToken('FetchForCsrfToken');

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,3 +1,0 @@
-import {createToken} from 'fusion-tokens';
-
-export const FetchForCsrfToken = createToken('FetchForCsrfToken');

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,3 @@
+import {createToken} from 'fusion-tokens';
+
+export const FetchForCsrfToken = createToken('FetchForCsrfToken');


### PR DESCRIPTION
Resolves #58 

Motivation:

There were numerous issues with the plugin:

- Tokens were not exported
- Token names were inconsistent with other packages
- Docs were incomplete
- It is weird to require every consumer of this package to create their own token in order to be able to use the package at all. The extra user-space token makes it harder to codemod and adds another possible point of failure for future automated migrations.

  The aliasing mechanism is also weird and confusing to understand, and overlaps in functionality with `app.enhance`.

```js
//before
import {FetchToken, createToken} from 'fusion-tokens';
import CsrfProtection from 'fusion-plugin-csrf-protection';

const BaseFetchToken = createToken('BaseFetchToken');
app.register(BaseFetchToken, fetch);
app.register(FetchToken, CsrfProtection).alias(FetchToken, BaseFetchToken);
```

```js
//after
import CsrfProtection, {FetchForCsrfToken} from 'fusion-plugin-csrf-protection';

app.register(FetchForCsrfToken, fetch);
app.register(FetchToken, CsrfProtection);
```

Resolution:

This PR exports all tokens, and renamed them to be consistent with other plugins. It also made the need for an extra user-space token obsolete