### PR TITLE
Fix flow 0.80.0 error in verifyExpiry

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -17,7 +17,7 @@ export function verifyMethod(
 ): $Values<typeof methods> {
   return methods[method];
 }
-export function verifyExpiry(token: string, expire: number): boolean {
+export function verifyExpiry(token: ?string, expire: number): boolean {
   if (!token) return false;
   const [timestamp] = token.split('-');
   const elapsed = Math.round(Date.now() / 1000) - Number(timestamp);


### PR DESCRIPTION
Getting an error with flow 0.80.0:

```
$ flow check
Error -------------------------------------------------- node_modules/fusion-plugin-csrf-protection/src/browser.js:41:38

Cannot call `verifyExpiry` with `token` bound to `token` because null [1] is incompatible with string [2].

   node_modules/fusion-plugin-csrf-protection/src/browser.js:41:38
    41|         const isValid = verifyExpiry(token, expire);
                                             ^^^^^

References:
   /private/tmp/flow/flowlib_3dea0f8d/bom.js:905:24
   905|     get(name: string): null | string;
                               ^^^^ [1]
   node_modules/fusion-plugin-csrf-protection/src/shared.js:20:37
    20| export function verifyExpiry(token: string, expire: number): boolean {
                                            ^^^^^^ [2]
```

It's complaining that since Headers#get can return `null`, we need to include that in the type signature. There should be no change in behavior since line 21 already checks for a falsey token.