### PR TITLE
Release v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fusion-plugin-csrf-protection",
   "description": "Generic CSRF-protection utility for use with any session manager or csrf secret/token generator",
   "repository": "fusionjs/fusion-plugin-csrf-protection",
-  "version": "2.0.1-0",
+  "version": "2.0.1",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
- Move eslint-plugin-jest to devDeps ([#173](https://github.com/fusionjs/fusion-plugin-csrf-protection/pull/173))